### PR TITLE
add option update object title

### DIFF
--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -157,11 +157,18 @@ function islandora_datastream_crud_push_datastream($ds_path) {
       $ds->mimeType = $version_data[$ds_filename]['mimetype'];
       $ds->label = $version_data[$ds_filename]['label'];
     }
+    //
     // If update object label and DC
     if ((drush_get_option('update_objectlabel')) AND ($dsid==="DC")) {
-      islandora_datastream_crud_write_crudlog($pid, $dsid, 'update object label');
+        $dublincore = file_get_contents($ds_path);
+        $dc_xml = new SimpleXmlElement($dublincore);
+        $namespaces = $dc_xml->getNameSpaces(true);
+        $dc = $dc_xml->children($namespaces['dc']);
+        $new_title = $dc->title;
+        $object->label = $new_title;
+        islandora_datastream_crud_write_crudlog($pid, $dsid, 'object label updated to '.$new_title);
     }
-    
+    //  
     try {
       $object->ingestDatastream($ds);
       drush_log(dt("!dsid datastream pushed to object !pid", array('!dsid' => $dsid, '!pid' => $pid)), 'ok');

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -157,6 +157,11 @@ function islandora_datastream_crud_push_datastream($ds_path) {
       $ds->mimeType = $version_data[$ds_filename]['mimetype'];
       $ds->label = $version_data[$ds_filename]['label'];
     }
+    // If update object label and DC
+    if ((drush_get_option('update_objectlabel')) AND ($dsid==="DC")) {
+      islandora_datastream_crud_write_crudlog($pid, $dsid, 'update object label');
+    }
+    
     try {
       $object->ingestDatastream($ds);
       drush_log(dt("!dsid datastream pushed to object !pid", array('!dsid' => $dsid, '!pid' => $pid)), 'ok');

--- a/islandora_datastream_crud.drush.inc
+++ b/islandora_datastream_crud.drush.inc
@@ -106,6 +106,10 @@ function islandora_datastream_crud_drush_command() {
         'description' => 'Optional. Include if the push is to revert datastream versions.' ,
         'value' => 'optional',
       ),
+      'update_objectlabel' => array(
+        'description' => 'Optional. Include if the push of DC datastream has to update object label derived from DC title element.' ,
+        'value' => 'optional',
+      ),
     ),
     'bootstrap' => DRUSH_BOOTSTRAP_DRUPAL_LOGIN,
   );


### PR DESCRIPTION
Mark, 
I added option to ingesting datastream (--update_objectlabel) that if enable the object title is updated with DC title field when DS is DC. I checked and I think is ok, please verify.
Giancarlo
