### PR TITLE
Issue 15

### DIFF
--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -148,7 +148,13 @@ function islandora_datastream_crud_push_datastream($ds_path) {
     $ds = isset($object[$dsid]) ? $object[$dsid] : $object->constructDatastream($dsid);
     $ds->setContentFromFile($ds_path);
     if (drush_get_option('datastreams_mimetype')) {
-      $ds->mimetype = drush_get_option('datastreams_mimetype');
+      // only update mime type if it is different othewise datastream will
+      // have two versions
+      // TODO - find a way to only create a single datastream updating both
+      // content and mime type without triggering the creation of 2 versions 
+      if($ds->mimetype != drush_get_option('datastreams_mimetype')){
+        $ds->mimetype = drush_get_option('datastreams_mimetype');
+      }
     }
     if (drush_get_option('datastreams_label')) {
       $ds->label = drush_get_option('datastreams_label');

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -149,10 +149,10 @@ function islandora_datastream_crud_push_datastream($ds_path) {
     $ds->setContentFromFile($ds_path);
     if (drush_get_option('datastreams_mimetype')) {
       // only update mime type if it is different othewise datastream will
-      // have two versions
+      // have two versions.
       // TODO - find a way to only create a single datastream updating both
-      // content and mime type without triggering the creation of 2 versions 
-      if($ds->mimetype != drush_get_option('datastreams_mimetype')){
+      // content and mime type without triggering the creation of 2 versions. 
+      if ($ds->mimetype != drush_get_option('datastreams_mimetype')) {
         $ds->mimetype = drush_get_option('datastreams_mimetype');
       }
     }

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -148,9 +148,9 @@ function islandora_datastream_crud_push_datastream($ds_path) {
     $ds = isset($object[$dsid]) ? $object[$dsid] : $object->constructDatastream($dsid);
     $ds->setContentFromFile($ds_path);
     if (drush_get_option('datastreams_mimetype')) {
-      // only update mime type if it is different othewise datastream will
+      // Only update mime type if it is different othewise datastream will
       // have two versions.
-      // TODO - find a way to only create a single datastream updating both
+      // @todo - find a way to only create a single datastream updating both
       // content and mime type without triggering the creation of 2 versions. 
       if ($ds->mimetype != drush_get_option('datastreams_mimetype')) {
         $ds->mimetype = drush_get_option('datastreams_mimetype');


### PR DESCRIPTION
When pushing datastreams, the current code will update the mime type if specified on command line even if it has the same mime type as the previous datastream it is replacing.  This creates two different versions of the datastream instead of a single new version.  It would be even better if both the content and mime type could be updated at once and then a single version inserted - however it does not look like there is an easy way to do this without working around the current core apis.  A comment was added to indicate this. 