### PR TITLE
Add --is_member_of option to fetch PIDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,12 +27,13 @@ The `islandora_datastream_crud_fetch_pids` command provides several options for 
 
 * `--namespace`: Lets you specify a namespace.
 * `--collection`: Lets you specify a collection PID.
+* `--is_member_of`: Lets you specify relationships to another parent object PID such as a Newspaper or Book.
 * `--content_model`: Lets you specify a content model PID.
 * `--with_dsid`: Lets you specify the ID of a datastream that objects must have.
 * `--without_dsid`: Lets you specify the ID of a datastream that objects must not have.
 * `--solr_query`: A raw Solr query. For example, `--solr_query=*:*` will retrieve all the PIDs in your repository; `--solr_query=dc.title:foo` will retrieve all the PIDs of objects that have the string 'foo' in their DC title fields; `--solr_query="RELS_EXT_isMemberOf_uri_s:info\:fedora/dailyplanet\:1"`will retrieve all newspaper issues that are part of the newspaper "dailyplanet:1".
 
-The `--collection`, `--content_model`, `--namespace`, `--with_dsid`, `--without_dsid`, and `--solr_query` options, if present, are ANDed together, so you can, for example, retrieve PIDs of objects that have a specific namespace within a collection. If the `--solr_query` option is used, it overrides `--content_model'`, `--namespace`, `--with_dsid`, `--without_dsid`, and `--collection`.
+The `--collection`, `--is_member_of`, `--content_model`, `--namespace`, `--with_dsid`, `--without_dsid`, and `--solr_query` options, if present, are ANDed together, so you can, for example, retrieve PIDs of objects that have a specific namespace within a collection. If the `--solr_query` option is used, it overrides `--content_model'`, `--namespace`, `--with_dsid`, `--without_dsid`, and `--collection`.
 
 You typically save the fetched PIDs to a PID file, whose path is specified using the `--pid_file` option. See 'The PID file' section below for more information.
 

--- a/islandora_datastream_crud.drush.inc
+++ b/islandora_datastream_crud.drush.inc
@@ -241,19 +241,12 @@ function drush_islandora_datastream_crud_fetch_pids() {
       }
     }
   }
-/*  if (drush_get_option('is_member_of')) {
-    if (!islandora_object_load(drush_get_option('is_member_of))) {
-      drush_set_error('COLLECTION_NOT_FOUND',
-        dt('The specified parent object (!is_member_of) is not found or is not accessible.',
-        array('!is_member_of' => drush_get_option('is_member_of'))));
-      }
-  } */
 
   // Build the Solr query.
   $query = '';
   $query_parts = array();
   if (drush_get_option('is_member_of')) {
-    $query_parts[] = 'RELS_EXT_isMemberOf_uri_t' . ':"' . drush_get_option('is_member_of'). '"';
+    $query_parts[] = 'RELS_EXT_isMemberOf_uri_t' . ':"' . drush_get_option('is_member_of') . '"';
   }
   if (drush_get_option('collection')) {
     $query_parts[] = 'RELS_EXT_isMemberOfCollection_uri_t' . ':"' . drush_get_option('collection') . '"';

--- a/islandora_datastream_crud.drush.inc
+++ b/islandora_datastream_crud.drush.inc
@@ -27,6 +27,9 @@ function islandora_datastream_crud_drush_command() {
       'collection' => array(
         'description' => 'The PID of the collection from which to select the objects.' ,
       ),
+      'is_member_of' => array(
+        'description' => 'The PID of the parent with the isMemberOf relationship.',
+      ),
       'with_dsid' => array(
         'description' => 'Limit to objects that have a datastream with the specified datastream ID.' ,
       ),
@@ -238,10 +241,20 @@ function drush_islandora_datastream_crud_fetch_pids() {
       }
     }
   }
+/*  if (drush_get_option('is_member_of')) {
+    if (!islandora_object_load(drush_get_option('is_member_of))) {
+      drush_set_error('COLLECTION_NOT_FOUND',
+        dt('The specified parent object (!is_member_of) is not found or is not accessible.',
+        array('!is_member_of' => drush_get_option('is_member_of'))));
+      }
+  } */
 
   // Build the Solr query.
   $query = '';
   $query_parts = array();
+  if (drush_get_option('is_member_of')) {
+    $query_parts[] = 'RELS_EXT_isMemberOf_uri_t' . ':"' . drush_get_option('is_member_of'). '"';
+  }
   if (drush_get_option('collection')) {
     $query_parts[] = 'RELS_EXT_isMemberOfCollection_uri_t' . ':"' . drush_get_option('collection') . '"';
   }


### PR DESCRIPTION
Addresses #20 

# What does this Pull Request do?

adds an --is_member_of option to the fetch_pids Drush command. Searches for objects with the isMemberOf relationship to a PID, allowing you to specify parent objects besides collections, such as Newspapers or Books.

# How should this be tested?

Run islandora_datastream_crud_fetch_pids and include the --is_member_of parameter to find objects with a Newspaper or Book parent. Make sure that this doesn't interrupt other kinds of queries.

# Additional Notes

I couldn't figure out how to report a Drush error if the parent doesn't exist; would appreciate some help there.

Examples:

* Does this change require documentation to be updated? 
* Does this change add any new dependencies? 
* Could this change impact execution of existing code?

# Interested parties

@mjordan 
