### PR TITLE
Add new without_cmodel option to fetch_pids

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ The `islandora_datastream_crud_fetch_pids` command provides several options for 
 * `--collection`: Lets you specify a collection PID.
 * `--is_member_of`: Lets you specify relationships to another parent object PID such as a Newspaper or Book.
 * `--content_model`: Lets you specify a content model PID.
+* `--without_cmodel`: Excludes objects with a specified content model from the results.
 * `--with_dsid`: Lets you specify the ID of a datastream that objects must have.
 * `--without_dsid`: Lets you specify the ID of a datastream that objects must not have.
 * `--solr_query`: A raw Solr query. For example, `--solr_query=*:*` will retrieve all the PIDs in your repository; `--solr_query=dc.title:foo` will retrieve all the PIDs of objects that have the string 'foo' in their DC title fields; `--solr_query="RELS_EXT_isMemberOf_uri_s:info\:fedora/dailyplanet\:1"`will retrieve all newspaper issues that are part of the newspaper "dailyplanet:1". For a more complex query, `--solr_query="RELS_EXT_isMemberOfCollection_uri_ms:info\:fedora\/ir\:citationCollection AND dc.title:citation AND -mods_genre_ms:Article"` will return all objects in the "ir:citationCollection" collection with a title containing the word "citation" but without the genre "Article".

--- a/islandora_datastream_crud.drush.inc
+++ b/islandora_datastream_crud.drush.inc
@@ -21,6 +21,9 @@ function islandora_datastream_crud_drush_command() {
       'content_model' => array(
         'description' => 'The content model of the objects you want to update.',
       ),
+      'without_cmodel' => array(
+         'description' => 'The content model you want to exclude from your list of objects.',
+      ),
       'namespace' => array(
         'description' => 'The namespace of the objects you want to update.',
       ),
@@ -280,7 +283,9 @@ function drush_islandora_datastream_crud_fetch_pids() {
   if (drush_get_option('content_model')) {
     $query_parts[] = 'RELS_EXT_hasModel_uri_t' . ':' . '"info:fedora/' . drush_get_option('content_model') . '"';
   }
-
+  if (drush_get_option('without_cmodel')) {
+    $query_parts[] = '-RELS_EXT_hasModel_uri_t' . ':' . '"info:fedora/' . drush_get_option('without_cmodel') . '"';
+  }
   if (count($query_parts) > 1) {
     $query = implode(' AND ', $query_parts);
   }


### PR DESCRIPTION
Covers issue #73 

# What does this Pull Request do?

Creates a new drush option, `--without_cmodel`, to exclude objects without a given cmodel from the PID list.

# How should this be tested?

* Create a query that gives you a list of objects with various CModels, such as `drush -u 1 islandora_datastream_crud_fetch_pids --with_dsid=TN --pid_file=/tmp/alltns.txt`
* Same query with a different pid_file and add the new option: `drush -u 1 islandora_datastream_crud_fetch_pids --with_dsid=TN --pid_file=/tmp/without_basic.txt --without_cmodel= islandora:sp_basic_image `
* The second pid_file should have fewer results, and exclude all objects with the specified content model.

@mjordan 