### PR TITLE
patdunlavey / sfulibrary_issue_53_ds_versions_delete --- Added abilit…

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,8 @@ the following command would add three datastreams (DS1, DS2, and DS3, all with a
 
 Another subset of the general workflow in which you do not fetch datastreams is to delete a datastream from a set of objects. To do this, you only need to specify the objects you want to delete the datastream from in the PID file, and the datastream ID you want to delete.
 
+Optionally, you can also specify datastream version numbers to be deleted, either as a list of version numbers, or as a range of version numbers. This can be helpful, for example, if you want to delete all but the current version (0) of a datastream on many objects.
+
 Note that you cannot delete the DC datastream. Fedora Commons requires that each object has a DC datastream.
 
 ### Exporting datastreams

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -52,7 +52,7 @@ function islandora_datastream_crud_retrieve_datastream($pid, $dsid, $dir) {
   if (!islandora_object_load($pid)) {
     drush_set_error('OBJECT_DOES_NOT_EXIST',
       dt('The specified object (!pid) does not exist or is not accessible.',
-      array('!pid' => $pid)));
+        array('!pid' => $pid)));
     return FALSE;
   }
   else {
@@ -147,7 +147,7 @@ function islandora_datastream_crud_push_datastream($ds_path, $regenerate_dc = FA
   if (!islandora_object_load($pid)) {
     drush_set_error('OBJECT_DOES_NOT_EXIST',
       dt('The specified object (!pid) does not exist or is not accessible.',
-      array('!pid' => $pid)));
+        array('!pid' => $pid)));
     return FALSE;
   }
   else {
@@ -210,11 +210,15 @@ function islandora_datastream_crud_push_datastream($ds_path, $regenerate_dc = FA
  *   The PID of the object to delete the datastream from.
  * @param string $dsid
  *   The ID of the datastream to delete.
+ * @param array $versions
+ *   An array containing either versions or a range
+ *   'versions' => array of version numbers
+ *   'range' => array with starting and ending version numbers
  *
  * @return bool
  *   TRUE if the deletion was successful, FALSE if not.
  */
-function islandora_datastream_crud_delete_datastream($pid, $dsid) {
+function islandora_datastream_crud_delete_datastream($pid, $dsid, $versions = array()) {
   module_load_include('inc', 'islandora', 'includes/utilities');
   if (!islandora_is_valid_pid($pid)) {
     drush_set_error('PID_IS_INVALID', dt('The PID (!pid) is not valid.',
@@ -238,19 +242,58 @@ function islandora_datastream_crud_delete_datastream($pid, $dsid) {
       return FALSE;
     }
 
-    try {
-      if ($object->purgeDatastream($dsid)) {
-        drush_log(dt("!dsid datastream purged from object !pid", array('!dsid' => $dsid, '!pid' => $pid)), 'ok');
-        islandora_datastream_crud_write_crudlog($pid, $dsid, 'deleted');
-        return TRUE;
+    if($versions) {
+      $datastream = $object[$dsid];
+      if(!$datastream->versionable) {
+        drush_log(dt("Datastream versions were specified, but !dsid datastream is not versionable in object !pid", array('!dsid' => $dsid, '!pid' => $pid)), 'error');
+        islandora_datastream_crud_write_crudlog($pid, $dsid, 'datastream not versionable');
+        return FALSE;
       }
+      $max_version = $datastream->count() - 1;
+      if (!empty($versions['range'])) {
+        $versions['versions'] = [];
+        $versions['range']['end'] = min($versions['range']['end'], $max_version);
+        for ($i = $versions['range']['start']; $i <= $versions['range']['end']; $i++) {
+          $versions['versions'][] = $i;
+        }
+      }
+      if (!empty($versions['versions'])) {
+        // Sort versions from high to low.
+        arsort($versions['versions']);
+        foreach ($versions['versions'] as $version) {
+          if (isset($datastream[$version])) {
+            try {
+              unset($datastream[$version]);
+              drush_log(dt("Version !version of !dsid datastream purged from object !pid", array('!version' => $version, '!dsid' => $dsid, '!pid' => $pid)), 'ok');
+              islandora_datastream_crud_write_crudlog($pid, $dsid, 'version deleted');
+            } catch (Exception $e) {
+              drupal_set_message(t('Error deleting version %v of %s datastream from object %o %e', [
+                '%v' => $version,
+                '%s' => $dsid,
+                '%o' => $object->label,
+                '%e' => $e->getMessage(),
+              ]), 'error');
+            }
+          }
+        }
+      }
+      return TRUE;
     }
-    catch (Exception $e) {
-      drush_log(dt("Error purging !dsid datastream from object !pid; details below.",
-        array('!dsid' => $dsid, '!pid' => $pid)), 'error');
-      drush_log($e->getMessage(), 'error');
-      islandora_datastream_crud_write_crudlog($pid, $dsid, 'not deleted');
-      return FALSE;
+    else {
+      try {
+        if ($object->purgeDatastream($dsid)) {
+          drush_log(dt("!dsid datastream purged from object !pid", array('!dsid' => $dsid, '!pid' => $pid)), 'ok');
+          islandora_datastream_crud_write_crudlog($pid, $dsid, 'deleted');
+          return TRUE;
+        }
+      }
+      catch (Exception $e) {
+        drush_log(dt("Error purging !dsid datastream from object !pid; details below.",
+          array('!dsid' => $dsid, '!pid' => $pid)), 'error');
+        drush_log($e->getMessage(), 'error');
+        islandora_datastream_crud_write_crudlog($pid, $dsid, 'not deleted');
+        return FALSE;
+      }
     }
   }
 }
@@ -265,6 +308,7 @@ function islandora_datastream_crud_delete_datastream($pid, $dsid) {
  */
 function islandora_datastream_crud_update_object_properties($object, $props) {
   if (isset($props['state'])) {
+    $pid = $object->id;
     if ($props['state'] != $object->state) {
       $object->state = $props['state'];
       drush_log(dt("State for object !pid updated to !state", array('!pid' => $object->id, '!state' => $props['state'])), 'ok');
@@ -402,8 +446,8 @@ function islandora_datastream_crud_regenerate_dc($object, $source_dsid) {
   }
   catch (Exception $e) {
     drush_log(dt("DC cannot be regenerated for !pid from its !dsid datastream because of an XSLT problem; details below",
-      array('!dsid' => $dsid, '!pid' => $object->id)), 'error');
-    islandora_datastream_crud_write_crudlog($object->id, $dsid, 'DC not regenerated');
+      array('!dsid' => $source_dsid, '!pid' => $object->id)), 'error');
+    islandora_datastream_crud_write_crudlog($object->id, $source_dsid, 'DC not regenerated');
     drush_log($e->getMessage(), 'error');
     return FALSE;
   }
@@ -549,4 +593,47 @@ function islandora_datastream_crud_read_version_data_log($path) {
   else {
     return FALSE;
   }
+}
+
+function islandora_datastream_crud_parse_versions_option($versions) {
+  $result = [];
+  $range_delimited = strpos($versions, '..');
+  if($range_delimited === FALSE) {
+    $versions = drupal_explode_tags($versions);
+    foreach($versions as $version) {
+      if(is_numeric($version)) {
+        $result['versions'][] = (int) $version;
+      }
+      else {
+        drush_set_error('VERSION_NUMBER_NOT_VALID', NULL, dt('Datastream version number !version is not valid.', array('!version' => $version)));
+        drupal_exit();
+      }
+    }
+  }
+  else {
+    preg_match("/(?<start>\S*)\.\.(?<end>\S*)/", $versions, $matches);
+    $matches = array_filter($matches);
+    if ((isset($matches['start']) && !is_numeric($matches['start'])) || (isset($matches['end']) && !is_numeric($matches['end']))) {
+      drush_set_error('VERSION_RANGE_NOT_VALID', NULL, dt('Datastream version range includes an invalid start or end value.'));
+      drupal_exit();
+    }
+
+    if (isset($matches['start']) || isset($matches['end'])) {
+      if (isset($matches['start']) && isset($matches['end'])) {
+        // Both ends of the range were provided.
+        $result['range']['start'] = (int) min($matches['start'], $matches['end']);
+        $result['range']['end'] = (int) max($matches['start'], $matches['end']);
+      }
+      else {
+        // Only one end of the range was provided, so the "start" and "end" keys matter.
+        $result['range']['start'] = !empty($matches['start']) ? (int) $matches['start'] : 0;
+        $result['range']['end'] = !empty($matches['end']) ? (int) $matches['end'] : 999999;
+      }
+    }
+    else {
+      drush_set_error('VERSION_RANGE_NOT_VALID', NULL, dt('Datastream version range is not valid.'));
+      drupal_exit();
+    }
+  }
+  return $result;
 }

--- a/islandora_datastream_crud.drush.inc
+++ b/islandora_datastream_crud.drush.inc
@@ -135,6 +135,8 @@ function islandora_datastream_crud_drush_command() {
     'description' => 'Delete datastreams.',
     'examples' => array(
       'drush islandora_datastream_crud_delete_datastreams --user=admin --dsid=FOO --pid_file=/tmp/delete_foo_from_these_objects.txt',
+      'drush islandora_datastream_crud_delete_datastreams --user=admin --dsid=FOO --versions="1,2" --pid_file=/tmp/delete_foo_from_these_objects.txt',
+      'drush islandora_datastream_crud_delete_datastreams --user=admin --dsid=FOO --versions="1.." --pid_file=/tmp/delete_foo_from_these_objects.txt',
     ),
     'options' => array(
       'pid_file' => array(
@@ -144,6 +146,9 @@ function islandora_datastream_crud_drush_command() {
       'dsid' => array(
         'description' => 'Datastream ID.',
         'required' => TRUE,
+      ),
+      'versions' => array(
+        'description' => 'If the versions option is present, then only datastream versions so specified list will be deleted. It may be expressed as a comma-separated list of datastream version numbers that you wish to delete, or as a range of version numbers, expressed as N..N. A range can also be specified as just one number, with the ".." after, which means delete this version and higher, or with the ".." before, which means delete version zero up to and including this version.'
       ),
       'datastreams_crud_log' => array(
         'description' => 'Optional. Absolute path to the CRUD log. If present, the PID, DSID, and a message will be written to the specified file.',
@@ -450,7 +455,8 @@ function drush_islandora_datastream_crud_push_datastreams() {
   module_load_include('inc', 'islandora_datastream_crud', 'includes/utilities');
   // If --pid_file was specified, only push to objects that have a PID there.
   if (drush_get_option('pid_file')) {
-    $pids = islandora_datastream_crud_read_pid_file(drush_get_option('pid_file'));
+    $pid_file = drush_get_option('pid_file');
+    $pids = islandora_datastream_crud_read_pid_file($pid_file);
     if (!count($pids)) {
       drush_set_error('NO_PIDS_IN_PID_FILE',
       dt('The specified PID file (!pid_file) contains no PIDS.',
@@ -505,20 +511,34 @@ function drush_islandora_datastream_crud_push_datastreams() {
  */
 function drush_islandora_datastream_crud_delete_datastreams() {
   $dsid = drush_get_option('dsid');
+  $versions = drush_get_option('versions');
   if ($dsid == 'DC') {
     drush_user_abort(dt('DC is a required datastream and cannot be deleted.'));
     exit;
   }
-  if (!drush_confirm(dt("You are about to delete (purge) the !dsid " .
-    "datastream from a set of objects in your repository. This action " .
-    "cannot be undone. Do you want to want to continue?",
-    array('!dsid' => drush_get_option('dsid'))))) {
+  module_load_include('inc', 'islandora_datastream_crud', 'includes/utilities');
+  if($versions) {
+    $confirm = dt("You are about to delete (purge) versions !versions from the !dsid " .
+      "datastream from a set of objects in your repository. This action " .
+      "cannot be undone. Do you want to continue?",
+      array('!dsid' => drush_get_option('dsid'), '!versions' => $versions));
+
+    $versions = islandora_datastream_crud_parse_versions_option($versions);
+  }
+  else {
+    $confirm = dt("You are about to delete (purge) the !dsid " .
+      "datastream from a set of objects in your repository. This action " .
+      "cannot be undone. Do you want to continue?",
+      array('!dsid' => drush_get_option('dsid')));
+  }
+
+  if (!drush_confirm($confirm)) {
     drush_user_abort(dt('Exiting, no datastreams deleted.'));
     exit;
   }
 
-  module_load_include('inc', 'islandora_datastream_crud', 'includes/utilities');
-  $pids = islandora_datastream_crud_read_pid_file(drush_get_option('pid_file'));
+  $pid_file = drush_get_option('pid_file');
+  $pids = islandora_datastream_crud_read_pid_file($pid_file);
   if (!count($pids)) {
     drush_set_error('NO_PIDS_IN_PID_FILE',
     dt('The specified PID file (!pid_file) contains no PIDS.',
@@ -528,7 +548,7 @@ function drush_islandora_datastream_crud_delete_datastreams() {
     if (drush_get_option('pause')) {
       sleep(drush_get_option('pause'));
     }
-    islandora_datastream_crud_delete_datastream($pid, $dsid);
+    islandora_datastream_crud_delete_datastream($pid, $dsid, $versions);
   }
 }
 
@@ -537,7 +557,8 @@ function drush_islandora_datastream_crud_delete_datastreams() {
  */
 function drush_islandora_datastream_crud_generate_derivatives() {
   module_load_include('inc', 'islandora_datastream_crud', 'includes/utilities');
-  $pids = islandora_datastream_crud_read_pid_file(drush_get_option('pid_file'));
+  $pid_file = drush_get_option('pid_file');
+  $pids = islandora_datastream_crud_read_pid_file($pid_file);
   $dsid = drush_get_option('source_dsid');
   if (!drush_confirm(dt("You are about to regenerate derivatives from the " .
     "!dsid datastream for !num object(s) in your repository. This action " .
@@ -590,7 +611,8 @@ function drush_islandora_datastream_crud_generate_derivatives() {
  */
 function drush_islandora_datastream_crud_update_object_properties() {
   module_load_include('inc', 'islandora_datastream_crud', 'includes/utilities');
-  $pids = islandora_datastream_crud_read_pid_file(drush_get_option('pid_file'));
+  $pid_file = drush_get_option('pid_file');
+  $pids = islandora_datastream_crud_read_pid_file($pid_file);
 
   $confirmation_message = '';
   $props = array();


### PR DESCRIPTION
# Github issue

(https://github.com/SFULibrary/islandora_datastream_crud/issues/53)

# What does this Pull Request do?

Adds a `--versions` option to `islandora_datastream_crud_delete_datastreams` so that specific datastream versions, or a range of datastream versions may be deleted.

# What's new?

* Added `versions` to the `islandora_datastream_crud_delete_datastreams` command options, along with a couple examples of its use.
* Added a function to `includes/utilities.inc` which parses and validates various forms of the user-supplied versions option. If the versions string does not validate, drush exits with an error.
* Modified `islandora_datastream_crud_delete_datastream` to add the `$versions` argument, and if present, to  try to use it to delete only the versions specified. 
* Added to the README.md file.

# How should this be tested?

* Create some objects with multiple copies of datastreams. E.g. regenerate multiple copies of the JP2 datastream on a book page. Add the corresponding PIDs to a file for use for the `--pid_file` option.
* Run the command with various forms of the `--versions` option. In each case, are the resulting datastream deletions what you expect and with no errors thrown? E.g.
  * `1..` - this is valid and will delete datastream versions numbered 1 and up.
  * `5..1` - this is valid (when both numbers are provided, their order does not matter), and will delete datastream versions numbered between 1 and 5 .
  * `1,4,3` - this is valid (order does not matter), and will delete datastream versions 1, 3, and 4, leaving versions formerly numbered 0, 2, 5, etc.
  * `blah` - this is invalid and will exit with an error.
  * `..` - this is invalid and will exit with an error.
  * `1,2,b` - this is invalid and will exit with an error.
* Run the command *without* the `--versions` option. Are all versions of the datastream deleted, and no errors?

# Additional Notes

* Does this change require documentation to be updated? 
_Yes, this PR includes an update to the README_
* Does this change add any new dependencies? 
_No_
* Could this change impact execution of existing code?
_It could impact other functioning of the `islandora_datastream_crud_delete_datastreams` command, so a variety of scenarios using that command should be tested. It's very unlikely to impact other commands provided by this module._

# Interested parties

@mjordan Aaron Krebek