### PR TITLE
Respect Namespaces in fetch_pids

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ If the `--solr_query` option is used, it overrides all other options.
 
 You typically save the fetched PIDs to a PID file, whose path is specified using the `--pid_file` option. See 'The PID file' section below for more information.
 
+If your site has namespace restrictions set in admin/islandora/configure, PID results will be filtered according to allowed namespaces. 
+
 ### Solr query examples
 
 * Versioned datastreams:

--- a/islandora_datastream_crud.drush.inc
+++ b/islandora_datastream_crud.drush.inc
@@ -339,7 +339,7 @@ function drush_islandora_datastream_crud_fetch_pids() {
   // Get the PIDs from the Solr query.
   module_load_include('inc', 'islandora_datastream_crud', 'includes/utilities');
   $pids = islandora_datastream_crud_query_solr($query);
-
+  $filter_counter = 0;
   if (!count($pids) || !$pids) {
     drush_set_error('NO_PIDS_FOUND',
       dt('Sorry, no PIDS were found.'));
@@ -348,6 +348,7 @@ function drush_islandora_datastream_crud_fetch_pids() {
     module_load_include('inc', 'islandora', 'includes/utilities');
     foreach ($pids as $pid) {
       if (islandora_namespace_accessible($pid)) {
+        $filter_counter++;
         if (drush_get_option('pid_file')) {
           file_put_contents(drush_get_option('pid_file'), $pid . PHP_EOL, FILE_APPEND);
         }
@@ -359,6 +360,7 @@ function drush_islandora_datastream_crud_fetch_pids() {
     if (drush_get_option('pid_file')) {
       drush_log(dt("PIDS written to file !pid_file", array('!pid_file' => drush_get_option('pid_file'))), 'ok');
     }
+    print($filter_counter . t(" namespace-accessible objects found.\n"));
   }
 }
 

--- a/islandora_datastream_crud.drush.inc
+++ b/islandora_datastream_crud.drush.inc
@@ -360,7 +360,10 @@ function drush_islandora_datastream_crud_fetch_pids() {
     if (drush_get_option('pid_file')) {
       drush_log(dt("PIDS written to file !pid_file", array('!pid_file' => drush_get_option('pid_file'))), 'ok');
     }
-    print($filter_counter . t(" namespace-accessible objects found.\n"));
+    $restrictions = variable_get('islandora_namespace_restriction_enforced', FALSE);
+    if ($restrictions == TRUE) {
+      print($filter_counter . t(" namespace-accessible objects found.\n"));
+    }
   }
 }
 

--- a/islandora_datastream_crud.drush.inc
+++ b/islandora_datastream_crud.drush.inc
@@ -346,15 +346,17 @@ function drush_islandora_datastream_crud_fetch_pids() {
   }
   else {
     foreach ($pids as $pid) {
+      if (islandora_namespace_accessible($pid)) {
+        if (drush_get_option('pid_file')) {
+          file_put_contents(drush_get_option('pid_file'), $pid . PHP_EOL, FILE_APPEND);
+        }
+        else {
+          drush_print($pid);
+        }
+      }
       if (drush_get_option('pid_file')) {
-        file_put_contents(drush_get_option('pid_file'), $pid . PHP_EOL, FILE_APPEND);
+        drush_log(dt("PIDS written to file !pid_file", array('!pid_file' => drush_get_option('pid_file'))), 'ok');
       }
-      else {
-        drush_print($pid);
-      }
-    }
-    if (drush_get_option('pid_file')) {
-      drush_log(dt("PIDS written to file !pid_file", array('!pid_file' => drush_get_option('pid_file'))), 'ok');
     }
   }
 }

--- a/islandora_datastream_crud.drush.inc
+++ b/islandora_datastream_crud.drush.inc
@@ -345,6 +345,7 @@ function drush_islandora_datastream_crud_fetch_pids() {
       dt('Sorry, no PIDS were found.'));
   }
   else {
+    module_load_include('inc', 'islandora', 'includes/utilities');
     foreach ($pids as $pid) {
       if (islandora_namespace_accessible($pid)) {
         if (drush_get_option('pid_file')) {

--- a/islandora_datastream_crud.drush.inc
+++ b/islandora_datastream_crud.drush.inc
@@ -354,9 +354,9 @@ function drush_islandora_datastream_crud_fetch_pids() {
         else {
           drush_print($pid);
         }
-      }
-      if (drush_get_option('pid_file')) {
-        drush_log(dt("PIDS written to file !pid_file", array('!pid_file' => drush_get_option('pid_file'))), 'ok');
+        if (drush_get_option('pid_file')) {
+          drush_log(dt("PIDS written to file !pid_file", array('!pid_file' => drush_get_option('pid_file'))), 'ok');
+        }
       }
     }
   }

--- a/islandora_datastream_crud.drush.inc
+++ b/islandora_datastream_crud.drush.inc
@@ -354,10 +354,10 @@ function drush_islandora_datastream_crud_fetch_pids() {
         else {
           drush_print($pid);
         }
-        if (drush_get_option('pid_file')) {
-          drush_log(dt("PIDS written to file !pid_file", array('!pid_file' => drush_get_option('pid_file'))), 'ok');
-        }
       }
+    }
+    if (drush_get_option('pid_file')) {
+      drush_log(dt("PIDS written to file !pid_file", array('!pid_file' => drush_get_option('pid_file'))), 'ok');
     }
   }
 }


### PR DESCRIPTION
Fixes Issue #91 

# What does this Pull Request do?

Adds namespace restriction check to islandora_datastream_crud_fetch_pids command.

# What's new?

Checks each returned PID for whether it's actually accessible before putting it in to the pid_file.

# How should this be tested?

- Ingest a couple of objects in a new namespace, sharing a cmodel with other existing objects
- Enable namespace restrictions at islandora/configure and exclude that namespace
- Run an `islandora_datastream_crud_fetch_pids` query that should return those objects and others (i.e. objects with that cmodel)
- Check the pid_file - it should return all objects in the repository with that cmodel
- Check out this branch
- Run the same fetch_pids query and check the pid_file -- it should not include these restricted objects anymore.

# Interested parties

@mjordan 