### PR TITLE
Allow DSIDs with underscore

### DIFF
--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -534,8 +534,16 @@ function islandora_datastream_crud_parse_dsfilename($filepath) {
   // The default case is namesapce_number_DSID.
   if (substr_count($filename, '_') == 2) {
     list($namespace, $number, $dsid) = explode('_', $filename);
+dd("Something happening");
     return array($namespace . ':' . $number, $dsid);
   }
+  // Covering underscores in the DSID
+  elseif (substr_count($filename, '_') == 3) {
+    list($namespace, $number, $dsid) = explode('_', $filename, 3);
+dd('DEBUG: ' . $namespace . ':' . $number . " " . $dsid);
+    return array($namespace . ':' . $number, $dsid);
+  }
+
   else {
     list($pid, $dsid) = explode($filename_separator, $filename);
     return array($pid, $dsid);

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -534,13 +534,11 @@ function islandora_datastream_crud_parse_dsfilename($filepath) {
   // The default case is namesapce_number_DSID.
   if (substr_count($filename, '_') == 2) {
     list($namespace, $number, $dsid) = explode('_', $filename);
-dd("Something happening");
     return array($namespace . ':' . $number, $dsid);
   }
   // Covering underscores in the DSID
   elseif (substr_count($filename, '_') == 3) {
     list($namespace, $number, $dsid) = explode('_', $filename, 3);
-dd('DEBUG: ' . $namespace . ':' . $number . " " . $dsid);
     return array($namespace . ':' . $number, $dsid);
   }
 


### PR DESCRIPTION
# Github issue 

#93 

# What does this Pull Request do?

Checks filename for presence of a third underscore, and if present, excludes the third underscore from the `explode` function. This means that a DSID with an underscore in it keeps its underscore.

# How should this be tested?

Create datastream files with normal filenames and filenames with underscores (e.g. `islandora_34_OBJ.tif` and `islandora_34_FULL_TEXT.asc`)

Without this PR, the `FULL_TEXT` datastream will fail, as the module fails to properly parse the filename. After checking out this PR, pushing both the `OBJ` datastream and the `FULL_TEXT` datastream (separately) will work.

# Interested parties

@mjordan 